### PR TITLE
NUnit tests run with Visual Studio's runner.

### DIFF
--- a/test/Itinero.Test/Itinero.Test.csproj
+++ b/test/Itinero.Test/Itinero.Test.csproj
@@ -8,12 +8,14 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <DebugType>full</DebugType>
+    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NetTopologySuite" Version="1.14.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="1.14.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
     <PackageReference Include="NUnit" Version="3.6.1" />
   </ItemGroup>
 


### PR DESCRIPTION
You will need to install and enable the (free) "NUnit 3 Test Adapter" extension from the Visual Studio marketplace.

Tested with Visual Studio Community 2017, version 15.1 (26403.7) Release.

Newtonsoft.Json version downgrade was to bring this in sync with the version that NetTopologySuite.IO.GeoJSON depends on... apparently, for some reason, some tests fail without this when run through the Visual Studio test runner.  There's probably a different way to get these tests to pass with 9.0.1, but I think this is good enough for now.