### PR TITLE
Resize arrays following a geometric progression.

### DIFF
--- a/src/Itinero.IO.Osm/Streams/UnsignedNodeIndex.cs
+++ b/src/Itinero.IO.Osm/Streams/UnsignedNodeIndex.cs
@@ -67,11 +67,8 @@ namespace Itinero.IO.Osm.Streams
         {
             int int1, int2;
             long2doubleInt(id, out int1, out int2);
-            
-            if (_idx + 2 >= _index.Length)
-            {
-                _index.Resize(_index.Length + (1024 * 1024));
-            }
+
+            _index.EnsureMinimumSize(_idx + 2);
             _index[_idx + 0] = int1;
             _index[_idx + 1] = int2;
             _idx += 2;
@@ -158,16 +155,7 @@ namespace Itinero.IO.Osm.Streams
         {
             var idx = TryGetIndex(id);
 
-            if ((idx * 2) + 1 >= _data.Length)
-            {
-                var start = _data.Length;
-                _data.Resize((idx * 2) + 1 + 1024);
-                for (var i = start; i < ((idx * 2) + 1 + 1024); i++)
-                {
-                    _data[i] = int.MaxValue;
-                }
-            }
-
+            _data.EnsureMinimumSize((idx * 2) + 2, int.MaxValue);
             _data[(idx * 2) + 0] = unchecked((int)vertex);
             _data[(idx * 2) + 1] = int.MinValue;
         }
@@ -179,16 +167,8 @@ namespace Itinero.IO.Osm.Streams
         {
             int lat = (int)(latitude * 10000000);
             int lon = (int)(longitude * 10000000);
-            
-            if ((idx * 2) + 1 >= _data.Length)
-            {
-                var start = _data.Length;
-                _data.Resize((idx * 2) + 1 + 1024);
-                for(var i = start; i < ((idx * 2) + 1 + 1024); i++)
-                {
-                    _data[i] = int.MaxValue;
-                }
-            }
+
+            _data.EnsureMinimumSize((idx * 2) + 2, int.MaxValue);
             _data[(idx * 2) + 0] = lat;
             _data[(idx * 2) + 1] = lon;
         }
@@ -481,7 +461,7 @@ namespace Itinero.IO.Osm.Streams
             longitude = (float)(lon / 10000000.0);
             return true;
         }
-        
+
         /// <summary>
         /// Returns the number of elements.
         /// </summary>

--- a/src/Itinero/Attributes/AttributesIndex.cs
+++ b/src/Itinero/Attributes/AttributesIndex.cs
@@ -336,10 +336,7 @@ namespace Itinero.Attributes
             id = (uint)_collectionIndex.Add(collection);
             if (_index != null)
             { // use next id.
-                if (_nextId >= _index.Length)
-                {
-                    _index.Resize(_index.Length + 1024);
-                }
+                _index.EnsureMinimumSize(_nextId + 1);
                 _index[_nextId] = id;
                 id = _nextId;
                 _nextId++;

--- a/src/Itinero/Data/Network/RoutingNetwork.cs
+++ b/src/Itinero/Data/Network/RoutingNetwork.cs
@@ -38,7 +38,6 @@ namespace Itinero.Data.Network
         private readonly GeometricGraph _graph;
         private readonly ArrayBase<uint> _edgeData;
         private readonly int _edgeDataSize = 2;
-        private const int BLOCK_SIZE = 1000;
 
         /// <summary>
         /// Creates a new routing network.
@@ -137,19 +136,6 @@ namespace Itinero.Data.Network
         }
 
         /// <summary>
-        /// Increase edge data size to fit at least the given edge.
-        /// </summary>
-        private void IncreaseSizeEdgeData(uint edgeId)
-        {
-            var size = _edgeData.Length;
-            while(edgeId >= size)
-            {
-                size += BLOCK_SIZE;
-            }
-            _edgeData.Resize(size);
-        }
-
-        /// <summary>
         /// Adds a new vertex.
         /// </summary>
         public void AddVertex(uint vertex, float latitude, float longitude)
@@ -194,10 +180,7 @@ namespace Itinero.Data.Network
             var edgeId = _graph.AddEdge(vertex1, vertex2,
                 Data.Edges.EdgeDataSerializer.Serialize(
                     data.Distance, data.Profile), shape);
-            if(edgeId >= _edgeData.Length)
-            {
-                this.IncreaseSizeEdgeData(edgeId);
-            }
+            _edgeData.EnsureMinimumSize(edgeId + 1);
             _edgeData[edgeId] = data.MetaId;
             return edgeId;
         }

--- a/src/Itinero/Data/Shortcuts/ShortcutsDb.cs
+++ b/src/Itinero/Data/Shortcuts/ShortcutsDb.cs
@@ -105,11 +105,7 @@ namespace Itinero.Data.Shortcuts
         {
             var stopsMetaId = _stopsMeta.Add(meta);
 
-            if (_stopsPointer + 2 >= _stops.Length)
-            {
-                _stops.Resize(_stops.Length + 100);
-            }
-
+            _stops.EnsureMinimumSize(_stopsPointer + 2);
             _stops[_stopsPointer + 0] = vertex;
             _stops[_stopsPointer + 1] = stopsMetaId;
 
@@ -137,13 +133,9 @@ namespace Itinero.Data.Shortcuts
         public uint Add(uint[] vertices, IAttributeCollection meta)
         {
             var shortcutMetaId = _shortcutsMeta.Add(meta);
-
-            while (_shortcutsPointer + vertices.Length + 1 >= _shortcuts.Length)
-            {
-                _shortcuts.Resize(_shortcuts.Length + 100);
-            }
-
             var size = (uint)vertices.Length + 2;
+
+            _shortcuts.EnsureMinimumSize(_shortcutsPointer + vertices.Length + 2);
             _shortcuts[_shortcutsPointer + 0] = size;
             _shortcuts[_shortcutsPointer + 1] = shortcutMetaId;
             for (uint i = 0; i < vertices.Length; i++)

--- a/src/Itinero/Extensions.cs
+++ b/src/Itinero/Extensions.cs
@@ -16,11 +16,12 @@
  *  limitations under the License.
  */
 
-using System.Collections.Generic;
-using System.IO;
 using Itinero.Attributes;
-using System.Globalization;
+using Reminiscence.Arrays;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Text;
 
 namespace Itinero
@@ -371,6 +372,76 @@ namespace Itinero
                 reversed[array.Length - 1 - i] = array[i];
             }
             return reversed;
+        }
+
+        /// <summary>
+        /// Ensures that this <see cref="ArrayBase{T}"/> has room for at least
+        /// the given number of elements, resizing if not.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of element stored in this array.
+        /// </typeparam>
+        /// <param name="array">
+        /// This array.
+        /// </param>
+        /// <param name="minimumSize">
+        /// The minimum number of elements that this array must fit.
+        /// </param>
+        public static void EnsureMinimumSize<T>(this ArrayBase<T> array, long minimumSize)
+        {
+            if (array.Length < minimumSize)
+            {
+                IncreaseMinimumSize(array, minimumSize, fillEnd: false, fillValueIfNeeded: default(T));
+            }
+        }
+
+        /// <summary>
+        /// Ensures that this <see cref="ArrayBase{T}"/> has room for at least
+        /// the given number of elements, resizing and filling the empty space
+        /// with the given value if not.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of element stored in this array.
+        /// </typeparam>
+        /// <param name="array">
+        /// This array.
+        /// </param>
+        /// <param name="minimumSize">
+        /// The minimum number of elements that this array must fit.
+        /// </param>
+        /// <param name="fillValue">
+        /// The value to use to fill in the empty spaces if we have to resize.
+        /// </param>
+        public static void EnsureMinimumSize<T>(this ArrayBase<T> array, long minimumSize, T fillValue)
+        {
+            if (array.Length < minimumSize)
+            {
+                IncreaseMinimumSize(array, minimumSize, fillEnd: true, fillValueIfNeeded: fillValue);
+            }
+        }
+
+        private static void IncreaseMinimumSize<T>(ArrayBase<T> array, long minimumSize, bool fillEnd, T fillValueIfNeeded)
+        {
+            long oldSize = array.Length;
+
+            // fast-forward, perhaps, through the first several resizes.
+            // Math.Max also ensures that we can resize from 0.
+            long size = Math.Max(1024, oldSize * 2);
+            while (size < minimumSize)
+            {
+                size *= 2;
+            }
+
+            array.Resize(size);
+            if (!fillEnd)
+            {
+                return;
+            }
+
+            for (long i = oldSize; i < size; i++)
+            {
+                array[i] = fillValueIfNeeded;
+            }
         }
     }
 

--- a/src/Itinero/Graphs/Directed/DirectedDynamicGraph.cs
+++ b/src/Itinero/Graphs/Directed/DirectedDynamicGraph.cs
@@ -117,48 +117,6 @@ namespace Itinero.Graphs.Directed
         }
 
         /// <summary>
-        /// Increases the size of the vector-array.
-        /// </summary>
-        private void IncreaseVertexSize()
-        {
-            this.IncreaseVertexSize(_vertices.Length + 10000);
-        }
-
-        /// <summary>
-        /// Increases the size of the vector-array.
-        /// </summary>
-        private void IncreaseVertexSize(long size)
-        {
-            if (_readonly) { throw new Exception("Graph is readonly."); }
-
-            var oldLength = _vertices.Length;
-            _vertices.Resize(size);
-            for(var i = oldLength; i < _vertices.Length; i++)
-            {
-                _vertices[i] = NO_EDGE;
-            }
-        }
-
-        /// <summary>
-        /// Increases the size of the vector-data array.
-        /// </summary>
-        private void IncreaseEdgeSize()
-        {
-            this.IncreaseEdgeSize(_edges.Length + 10000);
-        }
-
-        /// <summary>
-        /// Increases the memory allocation.
-        /// </summary>
-        private void IncreaseEdgeSize(long size)
-        {
-            if (_readonly) { throw new Exception("Graph is readonly."); }
-
-            var oldLength = _edges.Length;
-            _edges.Resize(size);
-        }
-
-        /// <summary>
         /// Adds an edge with the associated data.
         /// </summary>
         public uint AddEdge(uint vertex1, uint vertex2, uint data)
@@ -166,8 +124,7 @@ namespace Itinero.Graphs.Directed
             if (_readonly) { throw new Exception("Graph is readonly."); }
             if (vertex1 == vertex2) { throw new ArgumentException("Given vertices must be different."); }
             if (data > MAX_DYNAMIC_PAYLOAD) { throw new ArgumentOutOfRangeException("data", "Data payload too big."); }
-            while (vertex1 > _vertices.Length - 1) { this.IncreaseVertexSize(); }
-            while (vertex2 > _vertices.Length - 1) { this.IncreaseVertexSize(); }
+            _vertices.EnsureMinimumSize(Math.Max(vertex1, vertex2) + 1, NO_EDGE);
 
             var vertexPointer = vertex1;
             var edgePointer = _vertices[vertexPointer];
@@ -178,12 +135,8 @@ namespace Itinero.Graphs.Directed
                 _vertices[vertexPointer] = _nextEdgePointer;
                 edgeId = _nextEdgePointer;
 
-                if (_nextEdgePointer + 1 >= _edges.Length)
-                { // make sure we can add another edge.
-                    this.IncreaseEdgeSize();
-                }
-
-                edgeId = _nextEdgePointer;
+                // make sure we can add another edge.
+                _edges.EnsureMinimumSize(_nextEdgePointer + 2);
                 _edges[_nextEdgePointer] = vertex2;
                 _edges[_nextEdgePointer + 1] = DirectedDynamicGraph.AddLastEdgeAndLastFieldFlag(data);
                 _nextEdgePointer += 2;
@@ -211,19 +164,13 @@ namespace Itinero.Graphs.Directed
                     var newTotalSpace = NextPowerOfTwoOrPowerOfTwo(requiredSpace);
                     if (startPointer + totalSpace == _nextEdgePointer)
                     { // at the end, just make sure the edges array is big enough.
-                        while (newTotalSpace + startPointer >= _edges.Length)
-                        {
-                            this.IncreaseEdgeSize();
-                        }
+                        _edges.EnsureMinimumSize(newTotalSpace + startPointer + 1);
                         _nextEdgePointer += (newTotalSpace - totalSpace);
                     }
                     else
                     { // move everything to the end, there isn't enough free space here.
                         // make sure the edges array is big enough.
-                        while (newTotalSpace + _nextEdgePointer >= _edges.Length)
-                        {
-                            this.IncreaseEdgeSize();
-                        }
+                        _edges.EnsureMinimumSize(newTotalSpace + _nextEdgePointer + 1);
 
                         // move existing data to the end and update pointer.
                         _vertices[vertexPointer] = _nextEdgePointer;
@@ -261,8 +208,7 @@ namespace Itinero.Graphs.Directed
             {
                 if (data[i] > MAX_DYNAMIC_PAYLOAD) { throw new ArgumentOutOfRangeException("data", "One of the entries in the data payload is too big."); }
             }
-            while (vertex1 > _vertices.Length - 1) { this.IncreaseVertexSize(); }
-            while (vertex2 > _vertices.Length - 1) { this.IncreaseVertexSize(); }
+            _vertices.EnsureMinimumSize(Math.Max(vertex1, vertex2) + 1, NO_EDGE);
 
             var vertexPointer = vertex1;
             var edgePointer = _vertices[vertexPointer];
@@ -273,10 +219,8 @@ namespace Itinero.Graphs.Directed
                 _vertices[vertexPointer] = _nextEdgePointer;
                 edgeId = _nextEdgePointer;
 
-                if (_nextEdgePointer + data.Length >= _edges.Length)
-                { // make sure we can add another edge.
-                    this.IncreaseEdgeSize();
-                }
+                // make sure we can add another edge.
+                _edges.EnsureMinimumSize(_nextEdgePointer + data.Length + 1);
 
                 _edges[_nextEdgePointer] = vertex2;
                 for (var i = 0; i < data.Length - 1; i++)
@@ -309,19 +253,13 @@ namespace Itinero.Graphs.Directed
                     var newTotalSpace = NextPowerOfTwoOrPowerOfTwo(requiredSpace);
                     if (startPointer + totalSpace == _nextEdgePointer)
                     { // at the end, just make sure the edges array is big enough.
-                        while (newTotalSpace + startPointer >= _edges.Length)
-                        {
-                            this.IncreaseEdgeSize();
-                        }
+                        _edges.EnsureMinimumSize(newTotalSpace + startPointer + 1);
                         _nextEdgePointer += (newTotalSpace - totalSpace);
                     }
                     else
                     { // move everything to the end, there isn't enough free space here.
                         // make sure the edges array is big enough.
-                        while (newTotalSpace + _nextEdgePointer >= _edges.Length)
-                        {
-                            this.IncreaseEdgeSize();
-                        }
+                        _edges.EnsureMinimumSize(newTotalSpace + _nextEdgePointer + 1);
 
                         // move existing data to the end and update pointer.
                         _vertices[vertexPointer] = _nextEdgePointer;

--- a/src/Itinero/Graphs/Directed/DirectedMetaGraph.cs
+++ b/src/Itinero/Graphs/Directed/DirectedMetaGraph.cs
@@ -32,7 +32,6 @@ namespace Itinero.Graphs.Directed
         private readonly DirectedGraph _graph;
         private readonly ArrayBase<uint> _edgeData;
         private readonly int _edgeDataSize = int.MaxValue;
-        private const int BLOCK_SIZE = 1000;
 
         /// <summary>
         /// Creates a new graph.
@@ -95,27 +94,11 @@ namespace Itinero.Graphs.Directed
         {
             var oldEdgePointer = oldId * _edgeDataSize;
             var newEdgePointer = newId * _edgeDataSize;
-            if(newEdgePointer + _edgeDataSize > _edgeData.Length)
-            {
-                this.IncreaseSizeEdgeData((uint)(newEdgePointer + _edgeDataSize));
-            }
+            _edgeData.EnsureMinimumSize(newEdgePointer + _edgeDataSize + 1);
             for (var i = 0; i < _edgeDataSize; i++)
             {
                 _edgeData[newEdgePointer + i] = _edgeData[oldEdgePointer + i];
             }
-        }
-
-        /// <summary>
-        /// Increase edge data size to fit at least the given edge.
-        /// </summary>
-        private void IncreaseSizeEdgeData(uint edgePointer)
-        {
-            var size = _edgeData.Length;
-            while (edgePointer >= size)
-            {
-                size += BLOCK_SIZE;
-            }
-            _edgeData.Resize(size);
         }
 
         /// <summary>
@@ -127,11 +110,8 @@ namespace Itinero.Graphs.Directed
             if (_edgeDataSize != 1) { throw new ArgumentOutOfRangeException("Dimension of meta-data doesn't match."); }
 
             var edgeId = _graph.AddEdge(vertex1, vertex2, data);
-            if (edgeId >= _edgeData.Length)
-            {
-                this.IncreaseSizeEdgeData(edgeId);
-            }
             var edgePointer = edgeId * _edgeDataSize;
+            _edgeData.EnsureMinimumSize(edgePointer + 1);
             _edgeData[edgePointer + 0] = metaData;
             return edgeId;
         }
@@ -143,11 +123,8 @@ namespace Itinero.Graphs.Directed
         public uint AddEdge(uint vertex1, uint vertex2, uint[] data, params uint[] metaData)
         {
             var edgeId = _graph.AddEdge(vertex1, vertex2, data);
-            while ((edgeId + 1) * _edgeDataSize >= _edgeData.Length)
-            {
-                this.IncreaseSizeEdgeData((uint)((edgeId + 1) * _edgeDataSize));
-            }
             var edgePointer = edgeId * _edgeDataSize;
+            _edgeData.EnsureMinimumSize(edgePointer + _edgeDataSize + 1);
             for (var i = 0; i < _edgeDataSize; i++)
             {
                 _edgeData[edgePointer + i] = metaData[i];

--- a/src/Itinero/Graphs/Geometric/GeometricGraph.cs
+++ b/src/Itinero/Graphs/Geometric/GeometricGraph.cs
@@ -23,7 +23,6 @@ using Reminiscence.IO;
 using Reminiscence.IO.Streams;
 using System;
 using System.Collections.Generic;
-using Itinero.Algorithms;
 
 namespace Itinero.Graphs.Geometric
 {
@@ -198,21 +197,8 @@ namespace Itinero.Graphs.Geometric
         {
             _graph.AddVertex(vertex);
 
-            if (vertex * 2 + 1 >= _coordinates.Length)
-            { // increase coordinates length.
-                var newBlocks = 1;
-                while (vertex * 2 + 1 >= _coordinates.Length + (newBlocks * BLOCKSIZE * 2))
-                { // increase more.
-                    newBlocks++;
-                }
-
-                var oldLength = _coordinates.Length;
-                _coordinates.Resize(_coordinates.Length + (newBlocks * BLOCKSIZE * 2));
-                for (var i = oldLength; i < _coordinates.Length; i++)
-                {
-                    _coordinates[i] = NO_COORDINATE;
-                }
-            }
+            // increase coordinates length, if needed.
+            _coordinates.EnsureMinimumSize(vertex * 2 + 2, NO_COORDINATE);
             _coordinates[vertex * 2] = latitude;
             _coordinates[vertex * 2 + 1] = longitude;
         }
@@ -225,16 +211,8 @@ namespace Itinero.Graphs.Geometric
         {
             var edgeId = _graph.AddEdge(vertex1, vertex2, data);
 
-            if (edgeId >= _shapes.Length)
-            { // increase coordinates length.
-                var newBlocks = 1;
-                while(edgeId >= _shapes.Length + (BLOCKSIZE * newBlocks))
-                {
-                    newBlocks++;
-                }
-                _shapes.Resize(_shapes.Length + (newBlocks * BLOCKSIZE));
-            }
-
+            // increase coordinates length, if needed.
+            _shapes.EnsureMinimumSize(edgeId + 1);
             _shapes[edgeId] = shape;
             return edgeId;
         }

--- a/src/Itinero/Graphs/Geometric/Shapes/ShapesArray.cs
+++ b/src/Itinero/Graphs/Geometric/Shapes/ShapesArray.cs
@@ -20,7 +20,6 @@ using Reminiscence.Arrays;
 using Reminiscence.IO;
 using Reminiscence.IO.Streams;
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace Itinero.Graphs.Geometric.Shapes
@@ -181,10 +180,9 @@ namespace Itinero.Graphs.Geometric.Shapes
             if (pointer < 0 || shape.Count < size)
             { // add the coordinates at the end.
                 SetPointerAndSize(id, _nextPointer, shape.Count);
-                while (_nextPointer + (2 * (shape.Count + 1)) >= _coordinates.Length)
-                { // increase the size of the coordinates.
-                    _coordinates.Resize(_coordinates.Length + 1024);
-                }
+
+                // increase the size of the coordinates if needed.
+                _coordinates.EnsureMinimumSize(_nextPointer + (2 * shape.Count));
 
                 for (var i = 0; i < shape.Count; i++)
                 {

--- a/test/Itinero.Test/Itinero.Test.csproj
+++ b/test/Itinero.Test/Itinero.Test.csproj
@@ -34,6 +34,10 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   
   
 


### PR DESCRIPTION
Previously, we would always add a fixed quantity of elements during each resize.  This is nice when there are few elements, but it results in slower and slower resizes as more elements are added: every time we add O(1) elements, we have to copy O(N) elements, making a sequence of O(N) inserts require copying O(N * N) elements around.
Doubling every time a resize is needed, on the other hand, ensures that a sequence of O(N) inserts only requires us to copy O(N) elements around (amortized), at the expense of "wasting" space by an amount that's no greater than N / 2 elements compared to the prior approach.  This "waste" is only temporary while building the graphs; it goes away after a serialize / deserialize round-trip.

^ those were copied from the commit message... other notes:
- (EDIT): As I noted in the first comment below, the above is actually somewhat incorrect for arrays that are very large relative to an individual array block.  I should amend the commit message.  I'll leave it as-is until you've had a chance to look at it.
- I haven't done performance comparisons on *just* this change yet.  I'm also not able to run through Itinero.Test.Functional on this, because even with no changes on my end, it fails to resolve the point (49.5018, 6.06617).
- I opted to make these all consistent: an "ensure that there's at least *this much* room in this array" method, which is always called with the maximum index plus 1.  An alternative would be "ensure that the array is big enough to contain this index", which wouldn't make the callers have to do that "+1", it just didn't feel right to me.
- I was very careful to make sure that the "Ensure" methods are really small.  With the VS2017 compiler, the CIL for the larger one is 27 bytes long, and it doesn't do anything spooky, so the compiler **should**, **usually** inline the method, avoiding an actual function call in all cases except when it's time to actually resize.  This seems meaningful enough to bring up, given how many times these methods get called and how I'm competing with the old version which always inlined these checks.
- I also think `UnsignedNodeIndex.SortAndConvertIndex` does one more resize than it needs to, but I'm going to leave that one alone for now since its running time will be bounded by the sort anyway.

This took me a bit longer than I'd expected because apparently `ArrayBase<T>.Resize` **must** zero out the new slots when growing the array, so I had a lot of false failures on my unmanaged implementation.

I'll get a usable performance comparison later and post it in the comments.