### PR TITLE
Former MemoryArray<T> creators now use a factory.

### DIFF
--- a/src/Itinero.IO.Osm/Streams/UnsignedNodeIndex.cs
+++ b/src/Itinero.IO.Osm/Streams/UnsignedNodeIndex.cs
@@ -43,8 +43,8 @@ namespace Itinero.IO.Osm.Streams
         /// </summary>
         public UnsignedNodeIndex()
         {
-            _index = new MemoryArray<int>(1024 * 1024);
-            _data = new MemoryArray<int>(0);
+            _index = Context.ArrayFactory.CreateMemoryBackedArray<int>(1024 * 1024);
+            _data = Context.ArrayFactory.CreateMemoryBackedArray<int>(0);
             _overflows = new List<long>();
         }
 

--- a/src/Itinero/Attributes/AttributesIndex.cs
+++ b/src/Itinero/Attributes/AttributesIndex.cs
@@ -57,7 +57,7 @@ namespace Itinero.Attributes
 
             if ((_mode & AttributesIndexMode.IncreaseOne) == AttributesIndexMode.IncreaseOne)
             {
-                _index = new MemoryArray<uint>(1024);
+                _index = Context.ArrayFactory.CreateMemoryBackedArray<uint>(1024);
                 _nextId = 0;
             }
 
@@ -574,7 +574,7 @@ namespace Itinero.Attributes
                 var indexLengthBytes = new byte[8];
                 stream.Read(indexLengthBytes, 0, 8);
                 var indexLength = BitConverter.ToInt64(indexLengthBytes, 0);
-                var index = new MemoryArray<uint>(indexLength);
+                var index = Context.ArrayFactory.CreateMemoryBackedArray<uint>(indexLength);
                 index.CopyFrom(stream);
                 return new AttributesIndex(stringIndex, tagsIndex, index);
             }

--- a/src/Itinero/Context.cs
+++ b/src/Itinero/Context.cs
@@ -1,0 +1,17 @@
+﻿namespace Itinero
+{
+    /// <summary>
+    /// Holds static dependencies used throughout Itinero.
+    /// </summary>
+    /// <remarks>
+    /// Default implementations are all portable, but they may be overridden by
+    /// the application to provide optimized non-portable variants.
+    /// </remarks>
+    public static class Context
+    {
+        /// <summary>
+        /// The <see cref="IArrayFactory"/> used to create large arrays.
+        /// </summary>
+        public static IArrayFactory ArrayFactory = new DefaultArrayFactory();
+    }
+}

--- a/src/Itinero/Context.cs
+++ b/src/Itinero/Context.cs
@@ -12,6 +12,6 @@
         /// <summary>
         /// The <see cref="IArrayFactory"/> used to create large arrays.
         /// </summary>
-        public static IArrayFactory ArrayFactory = new DefaultArrayFactory();
+        public static IArrayFactory ArrayFactory { get; set; } = new DefaultArrayFactory();
     }
 }

--- a/src/Itinero/Data/Network/Restrictions/RestrictionsDb.cs
+++ b/src/Itinero/Data/Network/Restrictions/RestrictionsDb.cs
@@ -46,13 +46,13 @@ namespace Itinero.Data.Network.Restrictions
         public RestrictionsDb(int hashes = DEFAULT_HASHCOUNT)
         {
             _hasComplexRestrictions = false;
-            _hashes = new MemoryArray<uint>(hashes * 2);
+            _hashes = Context.ArrayFactory.CreateMemoryBackedArray<uint>(hashes * 2);
             for (var i = 0; i < _hashes.Length; i++)
             {
                 _hashes[i] = NO_DATA;
             }
-            _restrictions = new MemoryArray<uint>(DEFAULT_ARRAY_SIZE);
-            _index = new MemoryArray<uint>(DEFAULT_ARRAY_SIZE);
+            _restrictions = Context.ArrayFactory.CreateMemoryBackedArray<uint>(DEFAULT_ARRAY_SIZE);
+            _index = Context.ArrayFactory.CreateMemoryBackedArray<uint>(DEFAULT_ARRAY_SIZE);
         }
         
         /// <summary>
@@ -511,7 +511,7 @@ namespace Itinero.Data.Network.Restrictions
             ArrayBase<uint> hashes;
             if (profile == null || profile.HashesProfile == null)
             {
-                hashes = new MemoryArray<uint>(hashSize);
+                hashes = Context.ArrayFactory.CreateMemoryBackedArray<uint>(hashSize);
                 hashes.CopyFrom(stream);
             }
             else
@@ -526,7 +526,7 @@ namespace Itinero.Data.Network.Restrictions
             ArrayBase<uint> index;
             if (profile == null || profile.IndexProfile == null)
             {
-                index = new MemoryArray<uint>(indexSize);
+                index = Context.ArrayFactory.CreateMemoryBackedArray<uint>(indexSize);
                 index.CopyFrom(stream);
             }
             else
@@ -541,7 +541,7 @@ namespace Itinero.Data.Network.Restrictions
             ArrayBase<uint> restrictions;
             if (profile == null || profile.RestrictionsProfile == null)
             {
-                restrictions = new MemoryArray<uint>(restrictionSize);
+                restrictions = Context.ArrayFactory.CreateMemoryBackedArray<uint>(restrictionSize);
                 restrictions.CopyFrom(stream);
             }
             else

--- a/src/Itinero/Data/Network/RoutingNetwork.cs
+++ b/src/Itinero/Data/Network/RoutingNetwork.cs
@@ -45,7 +45,7 @@ namespace Itinero.Data.Network
         public RoutingNetwork(float maxEdgeDistance = Constants.DefaultMaxEdgeDistance)
         {
             _graph = new GeometricGraph(1);
-            _edgeData = new MemoryArray<uint>(_edgeDataSize * _graph.EdgeCount);
+            _edgeData = Context.ArrayFactory.CreateMemoryBackedArray<uint>(_edgeDataSize * _graph.EdgeCount);
             _maxEdgeDistance = maxEdgeDistance;
         }
         
@@ -57,7 +57,7 @@ namespace Itinero.Data.Network
             float maxEdgeDistance = Constants.DefaultMaxEdgeDistance)
         {
             _graph = new GeometricGraph(map, 1);
-            _edgeData = new MemoryArray<uint>(_edgeDataSize * _graph.EdgeCount);
+            _edgeData = Context.ArrayFactory.CreateMemoryBackedArray<uint>(_edgeDataSize * _graph.EdgeCount);
             _maxEdgeDistance = maxEdgeDistance;
         }
 
@@ -87,7 +87,7 @@ namespace Itinero.Data.Network
             float maxEdgeDistance = Constants.DefaultMaxEdgeDistance)
         {
             _graph = graph;
-            _edgeData = new MemoryArray<uint>(_edgeDataSize * graph.EdgeCount);
+            _edgeData = Context.ArrayFactory.CreateMemoryBackedArray<uint>(_edgeDataSize * graph.EdgeCount);
             _maxEdgeDistance = maxEdgeDistance;
         }
 
@@ -98,7 +98,7 @@ namespace Itinero.Data.Network
             float maxEdgeDistance = Constants.DefaultMaxEdgeDistance)
         {
             _graph = graph;
-            _edgeData = new MemoryArray<uint>(_edgeDataSize * graph.EdgeCount);
+            _edgeData = Context.ArrayFactory.CreateMemoryBackedArray<uint>(_edgeDataSize * graph.EdgeCount);
             _maxEdgeDistance = maxEdgeDistance;
         }
 
@@ -559,7 +559,7 @@ namespace Itinero.Data.Network
             ArrayBase<uint> edgeData;
             if (profile == null)
             { // just create arrays and read the data.
-                edgeData = new MemoryArray<uint>(edgeLength * edgeSize);
+                edgeData = Context.ArrayFactory.CreateMemoryBackedArray<uint>(edgeLength * edgeSize);
                 edgeData.CopyFrom(stream);
                 size += edgeLength * edgeSize * 4;
             }

--- a/src/Itinero/Data/Shortcuts/ShortcutsDb.cs
+++ b/src/Itinero/Data/Shortcuts/ShortcutsDb.cs
@@ -50,9 +50,9 @@ namespace Itinero.Data.Shortcuts
             _profile = profile;
 
             _stopsMeta = new AttributesIndex(AttributesIndexMode.ReverseAll);
-            _stops = new MemoryArray<uint>(100);
+            _stops = Context.ArrayFactory.CreateMemoryBackedArray<uint>(100);
             _shortcutsMeta = new AttributesIndex(AttributesIndexMode.ReverseAll);
-            _shortcuts = new MemoryArray<uint>(100);
+            _shortcuts = Context.ArrayFactory.CreateMemoryBackedArray<uint>(100);
         }
 
         /// <summary>
@@ -254,12 +254,12 @@ namespace Itinero.Data.Shortcuts
 
             // read stops meta and data.
             var stopsMeta = AttributesIndex.Deserialize(new LimitedStream(stream), true);
-            var stops = new MemoryArray<uint>(stopsPointer);
+            var stops = Context.ArrayFactory.CreateMemoryBackedArray<uint>(stopsPointer);
             stops.CopyFrom(stream);
 
             // read shortcuts meta and data.
             var shortcutsMeta = AttributesIndex.Deserialize(new LimitedStream(stream), true);
-            var shortcuts = new MemoryArray<uint>(shortcutsPointer);
+            var shortcuts = Context.ArrayFactory.CreateMemoryBackedArray<uint>(shortcutsPointer);
             shortcuts.CopyFrom(stream);
 
             return new ShortcutsDb(profile, metaDb, stopsMeta, stops, shortcutsMeta, shortcuts);

--- a/src/Itinero/DefaultArrayFactory.cs
+++ b/src/Itinero/DefaultArrayFactory.cs
@@ -1,0 +1,14 @@
+﻿using Reminiscence.Arrays;
+
+namespace Itinero
+{
+    /// <summary>
+    /// Implementation of <see cref="IArrayFactory"/> which uses the default
+    /// array types implemented and exposed in Reminiscence.
+    /// </summary>
+    public sealed class DefaultArrayFactory : IArrayFactory
+    {
+        /// <inheritdoc />
+        public ArrayBase<T> CreateMemoryBackedArray<T>(long size) => new MemoryArray<T>(size);
+    }
+}

--- a/src/Itinero/Graphs/Directed/DirectedDynamicGraph.cs
+++ b/src/Itinero/Graphs/Directed/DirectedDynamicGraph.cs
@@ -59,12 +59,12 @@ namespace Itinero.Graphs.Directed
             if (fixedEdgeDataSize < 1) { throw new ArgumentOutOfRangeException("fixedEdgeDataSize", "Fixed edge data size needs too greater than or equal to 1."); }
             if (sizeEstimate <= 0) { throw new ArgumentOutOfRangeException("sizeEstimate"); }
 
-            _vertices = new MemoryArray<uint>(sizeEstimate);
+            _vertices = Context.ArrayFactory.CreateMemoryBackedArray<uint>(sizeEstimate);
             for (var i = 0; i < _vertices.Length; i++)
             {
                 _vertices[i] = NO_EDGE;
             }
-            _edges = new MemoryArray<uint>(sizeEstimate * 4);
+            _edges = Context.ArrayFactory.CreateMemoryBackedArray<uint>(sizeEstimate * 4);
 
             _fixedEdgeDataSize = fixedEdgeDataSize;
             _edgeCount = 0;
@@ -533,7 +533,7 @@ namespace Itinero.Graphs.Directed
             this.Trim();
 
             // build a list of all vertices sorted by their first position.
-            var sortedVertices = new MemoryArray<uint>(_vertices.Length);
+            var sortedVertices = Context.ArrayFactory.CreateMemoryBackedArray<uint>(_vertices.Length);
             for (uint i = 0; i < sortedVertices.Length; i++)
             {
                 sortedVertices[i] = i;
@@ -1008,10 +1008,10 @@ namespace Itinero.Graphs.Directed
             ArrayBase<uint> edges;
             if (profile == null)
             { // just create arrays and read the data.
-                vertices = new MemoryArray<uint>(vertexLength);
+                vertices = Context.ArrayFactory.CreateMemoryBackedArray<uint>(vertexLength);
                 vertices.CopyFrom(stream);
                 size += vertexLength * 4;
-                edges = new MemoryArray<uint>(edgeArraySize);
+                edges = Context.ArrayFactory.CreateMemoryBackedArray<uint>(edgeArraySize);
                 edges.CopyFrom(stream);
                 size += edgeArraySize * 4;
             }

--- a/src/Itinero/Graphs/Directed/DirectedGraph.cs
+++ b/src/Itinero/Graphs/Directed/DirectedGraph.cs
@@ -77,8 +77,8 @@ namespace Itinero.Graphs.Directed
         /// </summary>
         public DirectedGraph(int edgeDataSize, long sizeEstimate, Action<uint, uint> switchEdge)
             : this(edgeDataSize, sizeEstimate,
-            new MemoryArray<uint>(sizeEstimate),
-            new MemoryArray<uint>(sizeEstimate * 3 * edgeDataSize + MINIMUM_EDGE_SIZE), switchEdge)
+            Context.ArrayFactory.CreateMemoryBackedArray<uint>(sizeEstimate),
+            Context.ArrayFactory.CreateMemoryBackedArray<uint>(sizeEstimate * 3 * edgeDataSize + MINIMUM_EDGE_SIZE), switchEdge)
         {
 
         }
@@ -548,7 +548,7 @@ namespace Itinero.Graphs.Directed
             this.Trim();
 
             // build a list of all vertices sorted by their first position.
-            var sortedVertices = new MemoryArray<uint>(_vertices.Length / VERTEX_SIZE);
+            var sortedVertices = Context.ArrayFactory.CreateMemoryBackedArray<uint>(_vertices.Length / VERTEX_SIZE);
             for (uint i = 0; i < sortedVertices.Length; i++)
             {
                 sortedVertices[i] = i;
@@ -904,10 +904,10 @@ namespace Itinero.Graphs.Directed
             ArrayBase<uint> edges;
             if (profile == null)
             { // just create arrays and read the data.
-                vertices = new MemoryArray<uint>(vertexLength * vertexSize);
+                vertices = Context.ArrayFactory.CreateMemoryBackedArray<uint>(vertexLength * vertexSize);
                 vertices.CopyFrom(stream);
                 size += vertexLength * vertexSize * 4;
-                edges = new MemoryArray<uint>(edgeLength * edgeSize);
+                edges = Context.ArrayFactory.CreateMemoryBackedArray<uint>(edgeLength * edgeSize);
                 edges.CopyFrom(stream);
                 size += edgeLength * edgeSize * 4;
             }

--- a/src/Itinero/Graphs/Directed/DirectedMetaGraph.cs
+++ b/src/Itinero/Graphs/Directed/DirectedMetaGraph.cs
@@ -52,7 +52,7 @@ namespace Itinero.Graphs.Directed
             {
                 this.SwitchEdge(x, y);
             });
-            _edgeData = new MemoryArray<uint>(_edgeDataSize * _graph.EdgeCount);
+            _edgeData = Context.ArrayFactory.CreateMemoryBackedArray<uint>(_edgeDataSize * _graph.EdgeCount);
         }
 
         /// <summary>
@@ -461,7 +461,7 @@ namespace Itinero.Graphs.Directed
             ArrayBase<uint> edges;
             if (profile == null)
             { // just create arrays and read the data.
-                edges = new MemoryArray<uint>(edgeLength * edgeSize);
+                edges = Context.ArrayFactory.CreateMemoryBackedArray<uint>(edgeLength * edgeSize);
                 edges.CopyFrom(stream);
                 size += edgeLength * edgeSize * 4;
             }

--- a/src/Itinero/Graphs/Geometric/GeometricGraph.cs
+++ b/src/Itinero/Graphs/Geometric/GeometricGraph.cs
@@ -53,7 +53,7 @@ namespace Itinero.Graphs.Geometric
         public GeometricGraph(int edgeDataSize, int size)
         {
             _graph = new Graph(edgeDataSize, size);
-            _coordinates = new MemoryArray<float>(size * 2);
+            _coordinates = Context.ArrayFactory.CreateMemoryBackedArray<float>(size * 2);
             for (var i = 0; i < _coordinates.Length; i++)
             {
                 _coordinates[i] = NO_COORDINATE;
@@ -628,7 +628,7 @@ namespace Itinero.Graphs.Geometric
             ShapesArray shapes;
             if (profile == null)
             { // don't use the stream, the read from it.
-                coordinates = new MemoryArray<float>(graph.VertexCount * 2);
+                coordinates = Context.ArrayFactory.CreateMemoryBackedArray<float>(graph.VertexCount * 2);
                 coordinates.CopyFrom(stream);
                 size += graph.VertexCount * 2 * 4;
                 long shapeSize;

--- a/src/Itinero/Graphs/Geometric/Shapes/ShapesArray.cs
+++ b/src/Itinero/Graphs/Geometric/Shapes/ShapesArray.cs
@@ -39,8 +39,8 @@ namespace Itinero.Graphs.Geometric.Shapes
         /// </summary>
         public ShapesArray(long size)
         {
-            _index = new MemoryArray<ulong>(size);
-            _coordinates = new MemoryArray<float>(size * 2 * ESTIMATED_SIZE);
+            _index = Context.ArrayFactory.CreateMemoryBackedArray<ulong>(size);
+            _coordinates = Context.ArrayFactory.CreateMemoryBackedArray<float>(size * 2 * ESTIMATED_SIZE);
 
             for (long i = 0; i < _index.Length; i++)
             {
@@ -380,10 +380,10 @@ namespace Itinero.Graphs.Geometric.Shapes
             ArrayBase<float> coordinates;
             if(copy)
             { // just create arrays and read the data.
-                index = new MemoryArray<ulong>(indexLength);
+                index = Context.ArrayFactory.CreateMemoryBackedArray<ulong>(indexLength);
                 index.CopyFrom(stream);
                 size += indexLength * 8;
-                coordinates = new MemoryArray<float>(coordinatesLength);
+                coordinates = Context.ArrayFactory.CreateMemoryBackedArray<float>(coordinatesLength);
                 size += coordinatesLength * 4;
                 coordinates.CopyFrom(stream);
             }

--- a/src/Itinero/Graphs/Graph.cs
+++ b/src/Itinero/Graphs/Graph.cs
@@ -56,8 +56,8 @@ namespace Itinero.Graphs
         /// </summary>
         public Graph(int edgeDataSize, long sizeEstimate)
             : this(edgeDataSize, sizeEstimate, 
-            new MemoryArray<uint>(sizeEstimate),
-            new MemoryArray<uint>(sizeEstimate * 3 * (MINIMUM_EDGE_SIZE + edgeDataSize)))
+            Context.ArrayFactory.CreateMemoryBackedArray<uint>(sizeEstimate),
+            Context.ArrayFactory.CreateMemoryBackedArray<uint>(sizeEstimate * 3 * (MINIMUM_EDGE_SIZE + edgeDataSize)))
         {
 
         }
@@ -1112,10 +1112,10 @@ namespace Itinero.Graphs
             ArrayBase<uint> edges;
             if (profile == null)
             { // just create arrays and read the data.
-                vertices = new MemoryArray<uint>(vertexLength * vertexSize);
+                vertices = Context.ArrayFactory.CreateMemoryBackedArray<uint>(vertexLength * vertexSize);
                 vertices.CopyFrom(stream);
                 size += vertexLength * vertexSize * 4;
-                edges = new MemoryArray<uint>(edgeLength * edgeSize);
+                edges = Context.ArrayFactory.CreateMemoryBackedArray<uint>(edgeLength * edgeSize);
                 edges.CopyFrom(stream);
                 size += edgeLength * edgeSize * 4;
             }

--- a/src/Itinero/IArrayFactory.cs
+++ b/src/Itinero/IArrayFactory.cs
@@ -1,0 +1,29 @@
+﻿using Reminiscence.Arrays;
+
+namespace Itinero
+{
+    /// <summary>
+    /// Factory for creating arrays.  These "arrays" are not your typical CLR
+    /// <c>T[]</c>.  They act the same for the most part, but they can be much
+    /// larger and do not necessarily have to be stored contiguously, nor even
+    /// fully in main memory.
+    /// </summary>
+    public interface IArrayFactory
+    {
+        /// <summary>
+        /// Creates an <see cref="ArrayBase{T}"/> fully backed by main memory,
+        /// with an initial capacity set to a given number of elements.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of element stored in the array.
+        /// </typeparam>
+        /// <param name="size">
+        /// The number of elements that the array needs to fit.
+        /// </param>
+        /// <returns>
+        /// An <see cref="ArrayBase{T}"/> fully backed by main memory, with its
+        /// size set to <paramref name="size"/> elements.
+        /// </returns>
+        ArrayBase<T> CreateMemoryBackedArray<T>(long size);
+    }
+}

--- a/test/Itinero.Test/ContextTests.cs
+++ b/test/Itinero.Test/ContextTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+using NUnit.Framework;
+using Reminiscence.Arrays;
+
+namespace Itinero.Test
+{
+    /// <summary>
+    /// Tests which ensure that our <see cref="Context"/> is set up to ensure,
+    /// by default, maximum backwards-compatibility at call sites that used to
+    /// used previously inline the default implementations; anything that wants
+    /// to make interesting use of <see cref="Context"/> needs to opt in.
+    /// </summary>
+    [TestFixture]
+    public class ContextTests
+    {
+        /// <summary>
+        /// The default factory in the context should be initialized properly.
+        /// </summary>
+        [Test]
+        public void DefaultArrayFactoryShouldReturnProperMemoryBackedArray()
+        {
+            const long SizeToUse = 592;
+            using (var array = Context.ArrayFactory.CreateMemoryBackedArray<Guid>(SizeToUse))
+            {
+                Assert.AreEqual(SizeToUse, array.Length, "Default returns an array that doesn't even obey the contract.");
+                Assert.IsInstanceOf<MemoryArray<Guid>>(array, "Default should return a standard MemoryArray<T> to ensure perfect backwards-compatibility.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows injecting a non-portable implementation instead.

While this doesn't directly affect anything that Itinero does **by itself**, it allows consumers of the library to inject an alternative implementation.

To see a potential impact of *just this change, alone* when the library consumer opts in, see the [wiki pages](https://github.com/airbreather/routing/wiki) I added to my fork.  The first column records total elapsed seconds since the application started.