### PR TITLE
Use IArrayFactory to create memory-backed arrays.

### DIFF
--- a/src/Itinero/Algorithms/Collections/Stack.cs
+++ b/src/Itinero/Algorithms/Collections/Stack.cs
@@ -34,7 +34,7 @@ namespace Itinero.Algorithms.Collections
         /// </summary>
         public Stack()
         {
-            _data = new MemoryArray<T>(1024);
+            _data = Context.ArrayFactory.CreateMemoryBackedArray<T>(1024);
         }
 
         private int _pointer = -1;

--- a/src/Itinero/Algorithms/Networks/Islands/IslandDetector.cs
+++ b/src/Itinero/Algorithms/Networks/Islands/IslandDetector.cs
@@ -109,7 +109,7 @@ namespace Itinero.Algorithms.Networks
             }
 
             // build index data structure and stack.
-            _index = new MemoryArray<uint>(vertexCount * 2);
+            _index = Context.ArrayFactory.CreateMemoryBackedArray<uint>(vertexCount * 2);
             for (var i = 0; i < _index.Length; i++)
             {
                 _index[i] = NO_DATA;

--- a/src/Itinero/Algorithms/Networks/Islands/IslandLabels.cs
+++ b/src/Itinero/Algorithms/Networks/Islands/IslandLabels.cs
@@ -31,7 +31,7 @@ namespace Itinero.Algorithms.Networks.Islands
     /// </summary>
     public class IslandLabels
     {
-        private readonly MemoryArray<uint> _labels;
+        private readonly ArrayBase<uint> _labels;
 
         public const uint NotSet = uint.MaxValue;
         public const uint NoAccess = uint.MaxValue - 1;
@@ -43,7 +43,7 @@ namespace Itinero.Algorithms.Networks.Islands
         /// </summary>
         internal IslandLabels()
         {
-            _labels = new MemoryArray<uint>(1);
+            _labels = Context.ArrayFactory.CreateMemoryBackedArray<uint>(1);
         }
         
         /// <summary>

--- a/src/Itinero/Attributes/MappedAttributesIndex.cs
+++ b/src/Itinero/Attributes/MappedAttributesIndex.cs
@@ -43,7 +43,7 @@ namespace Itinero.Attributes
         public MappedAttributesIndex(AttributesIndexMode mode = AttributesIndexMode.ReverseCollectionIndex |
                 AttributesIndexMode.ReverseStringIndex)
         {
-            _data = new MemoryArray<uint>(1024);
+            _data = Context.ArrayFactory.CreateMemoryBackedArray<uint>(1024);
             _attributes = new AttributesIndex(mode);
             _reverseIndex = new HugeDictionary<uint, int>();
 

--- a/src/Itinero/Data/Meta/MetaCollection.cs
+++ b/src/Itinero/Data/Meta/MetaCollection.cs
@@ -220,7 +220,7 @@ namespace Itinero.Data
             ArrayBase<T> data;
             if (profile == null)
             { // just create arrays and read the data.
-                data = new MemoryArray<T>(length);
+                data = Context.ArrayFactory.CreateMemoryBackedArray<T>(length);
                 data.CopyFrom(stream);
             }
             else
@@ -256,7 +256,7 @@ namespace Itinero.Data
             this.VerifyType();
 
             _length = 0;
-            _data = new MemoryArray<T>(capacity);
+            _data = Context.ArrayFactory.CreateMemoryBackedArray<T>(capacity);
             _empty = empty;
         }
 


### PR DESCRIPTION
When I submitted #97, I updated everything that created `MemoryArray<T>` instances to instead go through `IArrayFactory` (at least... I'm pretty sure I did).

Since that was merged, a few more things started directly creating `MemoryArray<T>` instances.  I think it may make sense to switch them too.