### PR TITLE
fixes IndexOutOfRangeException for ways which don't end in a core node

### DIFF
--- a/src/Itinero.IO.Osm/Streams/RouterDbStreamTarget.cs
+++ b/src/Itinero.IO.Osm/Streams/RouterDbStreamTarget.cs
@@ -457,7 +457,7 @@ namespace Itinero.IO.Osm.Streams
                         var toNode = long.MaxValue;
                         while (true)
                         {
-                            if (!this.TryGetValue(way.Nodes[node], out coordinate, out isCore))
+                            if (node >= way.Nodes.Length || !this.TryGetValue(way.Nodes[node], out coordinate, out isCore))
                             { // an incomplete way, node not in source.
                                 return;
                             }


### PR DESCRIPTION
I ran into a problem with Itinero crashing when tagging some ways:

```
System.IndexOutOfRangeException
  HResult=0x80131508
  Message=Index was outside the bounds of the array.
  Source=Itinero.IO.Osm
  StackTrace:
   at Itinero.IO.Osm.Streams.RouterDbStreamTarget.AddWay(Way way)
   at OsmSharp.Streams.OsmStreamTarget.DoPull(Boolean ignoreNodes, Boolean ignoreWays, Boolean ignoreRelations)
   at Itinero.IO.Osm.Streams.RouterDbStreamTarget.OnBeforePull()
   at OsmSharp.Streams.OsmStreamTarget.Pull()
   at Itinero.IO.Osm.RouterDbExtensions.LoadOsmData(RouterDb db, OsmStreamSource[] sources, LoadSettings settings, Vehicle[] vehicles)
```

This little change fixes it.