### PR TITLE
Updated to NTS 2.0 and removed use of GeoAPI where required.

### DIFF
--- a/Itinero.sln
+++ b/Itinero.sln
@@ -1,20 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4B330D21-2EE5-4C34-B716-0DB1FBC58E29}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C142786B-F60E-4B6B-B9F2-1D25C3A3D7B5}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
+		build.sh = build.sh
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE.md = LICENSE.md
 		NOTICE.md = NOTICE.md
 		README.md = README.md
 		SharedAssemblyVersion.cs = SharedAssemblyVersion.cs
 		test.sh = test.sh
-		build.sh = build.sh
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{7E594B3F-4CA9-4198-B90D-DD16972D0481}"
@@ -47,13 +47,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Itinero.Test", "test\Itiner
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Itinero.Test.Functional", "test\Itinero.Test.Functional\Itinero.Test.Functional.csproj", "{9D719B37-42DD-486A-9FFC-CD8B0230D114}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Itinero.Geo", "src\Itinero.Geo\Itinero.Geo.csproj", "{87E5FF87-E75F-4462-937F-538AB570EE1F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Itinero.Geo", "src\Itinero.Geo\Itinero.Geo.csproj", "{87E5FF87-E75F-4462-937F-538AB570EE1F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Itinero.IO.Shape", "src\Itinero.IO.Shape\Itinero.IO.Shape.csproj", "{C18E5106-ECC6-4C7B-A611-7D8514B0D3BD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Itinero.IO.Shape", "src\Itinero.IO.Shape\Itinero.IO.Shape.csproj", "{C18E5106-ECC6-4C7B-A611-7D8514B0D3BD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Shape", "samples\Sample.Shape\Sample.Shape.csproj", "{EB6A7F79-3540-4E31-A1A8-3ADA0F232E67}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Shape", "samples\Sample.Shape\Sample.Shape.csproj", "{EB6A7F79-3540-4E31-A1A8-3ADA0F232E67}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.DynamicProfiles", "samples\Sample.DynamicProfiles\Sample.DynamicProfiles.csproj", "{8DED4253-89E6-4333-9750-E830DB789B2D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.DynamicProfiles", "samples\Sample.DynamicProfiles\Sample.DynamicProfiles.csproj", "{8DED4253-89E6-4333-9750-E830DB789B2D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Reminiscence", "..\reminiscence\src\Reminiscence\Reminiscence.csproj", "{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -151,6 +153,14 @@ Global
 		{8DED4253-89E6-4333-9750-E830DB789B2D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8DED4253-89E6-4333-9750-E830DB789B2D}.Release|x64.ActiveCfg = Release|Any CPU
 		{8DED4253-89E6-4333-9750-E830DB789B2D}.Release|x64.Build.0 = Release|Any CPU
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -167,9 +177,7 @@ Global
 		{C18E5106-ECC6-4C7B-A611-7D8514B0D3BD} = {4B330D21-2EE5-4C34-B716-0DB1FBC58E29}
 		{EB6A7F79-3540-4E31-A1A8-3ADA0F232E67} = {77BC0AC3-41A6-4672-A3AB-9C27710756BE}
 		{8DED4253-89E6-4333-9750-E830DB789B2D} = {77BC0AC3-41A6-4672-A3AB-9C27710756BE}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {647068E9-BC76-4E51-B225-D6BBD4689F76}
+		{4E260B9B-7656-4EC3-89A1-BB8ABEB483E9} = {4B330D21-2EE5-4C34-B716-0DB1FBC58E29}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B9A2B2E1-FE8E-4F87-80E2-1A3F620ED1E8}

--- a/src/Itinero.Geo/Extensions.cs
+++ b/src/Itinero.Geo/Extensions.cs
@@ -29,15 +29,15 @@ namespace Itinero.Geo
         /// <summary>
         /// Converts the coordinate to a geoapi coordinate.
         /// </summary>
-        public static GeoAPI.Geometries.Coordinate ToCoordinate(this LocalGeo.Coordinate coordinate)
+        public static NetTopologySuite.Geometries.Coordinate ToCoordinate(this LocalGeo.Coordinate coordinate)
         {
-            return new GeoAPI.Geometries.Coordinate(coordinate.Longitude, coordinate.Latitude);
+            return new NetTopologySuite.Geometries.Coordinate(coordinate.Longitude, coordinate.Latitude);
         }
 
         /// <summary>
         /// Converts a geoapi coordinate to a coordinate.
         /// </summary>
-        public static LocalGeo.Coordinate FromCoordinate(this GeoAPI.Geometries.Coordinate coordinate)
+        public static LocalGeo.Coordinate FromCoordinate(this NetTopologySuite.Geometries.Coordinate coordinate)
         {
             return new LocalGeo.Coordinate((float)coordinate.Y, (float)coordinate.X);
         }
@@ -45,14 +45,14 @@ namespace Itinero.Geo
         /// <summary>
         /// Converts a list of coordinates to geoapi coordinates.
         /// </summary>
-        public static List<GeoAPI.Geometries.Coordinate> ToCoordinates(this List<LocalGeo.Coordinate> coordinates)
+        public static List<NetTopologySuite.Geometries.Coordinate> ToCoordinates(this List<LocalGeo.Coordinate> coordinates)
         {
             if (coordinates == null)
             {
                 return null;
             }
 
-            var geoApiCoordinates = new List<GeoAPI.Geometries.Coordinate>(coordinates.Count);
+            var geoApiCoordinates = new List<NetTopologySuite.Geometries.Coordinate>(coordinates.Count);
             for (var i = 0; i < coordinates.Count; i++)
             {
                 geoApiCoordinates.Add(coordinates[i].ToCoordinate());
@@ -63,14 +63,14 @@ namespace Itinero.Geo
         /// <summary>
         /// Converts a list of coordinates to geoapi coordinates.
         /// </summary>
-        public static GeoAPI.Geometries.Coordinate[] ToCoordinatesArray(this List<LocalGeo.Coordinate> coordinates)
+        public static NetTopologySuite.Geometries.Coordinate[] ToCoordinatesArray(this List<LocalGeo.Coordinate> coordinates)
         {
             if (coordinates == null)
             {
                 return null;
             }
 
-            var geoApiCoordinates = new GeoAPI.Geometries.Coordinate[coordinates.Count];
+            var geoApiCoordinates = new NetTopologySuite.Geometries.Coordinate[coordinates.Count];
             for (var i = 0; i < coordinates.Count; i++)
             {
                 geoApiCoordinates[i] = coordinates[i].ToCoordinate();
@@ -81,14 +81,14 @@ namespace Itinero.Geo
         /// <summary>
         /// Converts a list of coordinates to geoapi coordinates.
         /// </summary>
-        public static List<GeoAPI.Geometries.Coordinate> ToCoordinates(this LocalGeo.Coordinate[] coordinates)
+        public static List<NetTopologySuite.Geometries.Coordinate> ToCoordinates(this LocalGeo.Coordinate[] coordinates)
         {
             if (coordinates == null)
             {
                 return null;
             }
 
-            var geoApiCoordinates = new List<GeoAPI.Geometries.Coordinate>(coordinates.Length);
+            var geoApiCoordinates = new List<NetTopologySuite.Geometries.Coordinate>(coordinates.Length);
             for (var i = 0; i < coordinates.Length; i++)
             {
                 geoApiCoordinates.Add(coordinates[i].ToCoordinate());
@@ -99,14 +99,14 @@ namespace Itinero.Geo
         /// <summary>
         /// Converts an array of coordinates to an array of geoapi coordinates.
         /// </summary>
-        public static GeoAPI.Geometries.Coordinate[] ToCoordinatesArray(this LocalGeo.Coordinate[] coordinates)
+        public static NetTopologySuite.Geometries.Coordinate[] ToCoordinatesArray(this LocalGeo.Coordinate[] coordinates)
         {
             if (coordinates == null)
             {
                 return null;
             }
 
-            var geoApiCoordinates = new GeoAPI.Geometries.Coordinate[coordinates.Length];
+            var geoApiCoordinates = new NetTopologySuite.Geometries.Coordinate[coordinates.Length];
             for (var i = 0; i < coordinates.Length; i++)
             {
                 geoApiCoordinates[i] = coordinates[i].ToCoordinate();
@@ -163,10 +163,10 @@ namespace Itinero.Geo
         /// </summary>
         public static NetTopologySuite.Geometries.LineString ToLineString(this Algorithms.Networks.Analytics.Trees.Models.TreeEdge edge)
         {
-            var coordinates = new GeoAPI.Geometries.Coordinate[edge.Shape.Length];
+            var coordinates = new NetTopologySuite.Geometries.Coordinate[edge.Shape.Length];
             for(var i = 0; i < coordinates.Length; i++)
             {
-                coordinates[i] = new GeoAPI.Geometries.Coordinate(edge.Shape[i][0], edge.Shape[i][1]);
+                coordinates[i] = new NetTopologySuite.Geometries.Coordinate(edge.Shape[i][0], edge.Shape[i][1]);
             }
             return new NetTopologySuite.Geometries.LineString(coordinates);
         }
@@ -213,7 +213,7 @@ namespace Itinero.Geo
         /// </summary>
         public static void Add(this NetTopologySuite.Features.FeatureCollection features, NetTopologySuite.Features.FeatureCollection featuresToAdd)
         {
-            foreach(var feature in featuresToAdd.Features)
+            foreach(var feature in featuresToAdd)
             {
                 features.Add(feature);
             }

--- a/src/Itinero.Geo/Itinero.Geo.csproj
+++ b/src/Itinero.Geo/Itinero.Geo.csproj
@@ -20,8 +20,8 @@
     <RepositoryType>osm, openstreetmap, routing, mapping</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NetTopologySuite" Version="1.15.1" />
-    <PackageReference Include="NetTopologySuite.Features" Version="1.15.1" />
+    <PackageReference Include="NetTopologySuite" Version="2.0.0" />
+    <PackageReference Include="NetTopologySuite.Features" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Itinero\Itinero.csproj" />

--- a/src/Itinero.Geo/Navigation/InstructionExtensions.cs
+++ b/src/Itinero.Geo/Navigation/InstructionExtensions.cs
@@ -16,7 +16,6 @@
  *  limitations under the License.
  */
 
- using GeoAPI.Geometries;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using Itinero.Navigation;

--- a/src/Itinero.Geo/RouteExtensions.cs
+++ b/src/Itinero.Geo/RouteExtensions.cs
@@ -32,9 +32,10 @@ namespace Itinero.Geo
         /// <summary>
         /// Returns the bounding box around this route.
         /// </summary>
-        public static GeoAPI.Geometries.Envelope GetBox(this Route route)
+        public static Envelope GetBox(this Route route)
         {
             if (route == null) { throw new ArgumentNullException("route"); }
+
             if (route.Shape  == null)
             {
                 return null;
@@ -42,16 +43,16 @@ namespace Itinero.Geo
 
             if (route.Shape.Length == 1)
             {
-                return new GeoAPI.Geometries.Envelope(
-                    route.Shape[0].ToCoordinate(), route.Shape[0].ToCoordinate());
+                return new Envelope(route.Shape[0].ToCoordinate(), route.Shape[0].ToCoordinate());
             }
 
-            var envelope = new GeoAPI.Geometries.Envelope(
-                    route.Shape[0].ToCoordinate(), route.Shape[1].ToCoordinate());
-            for(var i = 2; i < route.Shape.Length; i++)
+            var envelope = new Envelope(route.Shape[0].ToCoordinate(), route.Shape[1].ToCoordinate());
+
+            for (var i = 2; i < route.Shape.Length; i++)
             {
                 envelope.ExpandToInclude(route.Shape[i].ToCoordinate());
             }
+
             return envelope;
         }
 
@@ -96,7 +97,7 @@ namespace Itinero.Geo
                         Logging.Logger.Log("RouteExtensions", Logging.TraceEventType.Warning, 
                             "Invalid meta-data detected on route. One of the meta-description has a shape index smaller than the previous one.");
                     }
-                    var shape = new GeoAPI.Geometries.Coordinate[current.Shape - previous.Shape + 1];
+                    var shape = new Coordinate[current.Shape - previous.Shape + 1];
                     for(var s = previous.Shape; s <= current.Shape; s++)
                     {
                         if (s < 0 || s >= route.Shape.Length)
@@ -116,7 +117,7 @@ namespace Itinero.Geo
                 for (var i = 0; i < route.Stops.Length; i++)
                 {
                     featureCollection.Add(new Feature(
-                        new Point(new GeoAPI.Geometries.Coordinate(
+                        new Point(new Coordinate(
                             route.Stops[i].Coordinate.ToCoordinate())), 
                         route.Stops[i].Attributes.ToAttributesTable()));
                 }

--- a/src/Itinero.Geo/RouterDbExtensions.cs
+++ b/src/Itinero.Geo/RouterDbExtensions.cs
@@ -16,7 +16,6 @@
  *  limitations under the License.
  */
 
- using GeoAPI.Geometries;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using Itinero.Data.Network;

--- a/src/Itinero.Geo/RouterExtensions.cs
+++ b/src/Itinero.Geo/RouterExtensions.cs
@@ -34,7 +34,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest points on the routing network that's routable for the given profile(s).
         /// </summary>
-        public static Result<RouterPoint>[] TryResolve(this Router router, Profile profile, GeoAPI.Geometries.Coordinate[] coordinates,
+        public static Result<RouterPoint>[] TryResolve(this Router router, Profile profile, NetTopologySuite.Geometries.Coordinate[] coordinates,
             float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
             if (coordinates == null) { throw new ArgumentNullException("coordinate"); }
@@ -50,7 +50,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest point on the routing network that's routable for the given profiles.
         /// </summary>
-        public static Result<RouterPoint> TryResolve(this Router router, Profile profile, GeoAPI.Geometries.Coordinate coordinate,
+        public static Result<RouterPoint> TryResolve(this Router router, Profile profile, NetTopologySuite.Geometries.Coordinate coordinate,
             float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
             return router.TryResolve(new Profile[] { profile }, coordinate, searchDistanceInMeter);
@@ -59,7 +59,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest points on the routing network that's routable for the given profile(s).
         /// </summary>
-        public static Result<RouterPoint>[] TryResolve(this Router router, Profile[] profiles, GeoAPI.Geometries.Coordinate[] coordinates,
+        public static Result<RouterPoint>[] TryResolve(this Router router, Profile[] profiles, NetTopologySuite.Geometries.Coordinate[] coordinates,
             float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
             if (coordinates == null) { throw new ArgumentNullException("coordinate"); }
@@ -75,7 +75,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest point on the routing network that's routable for the given profiles.
         /// </summary>
-        public static Result<RouterPoint> TryResolve(this Router router, Profile[] profiles, GeoAPI.Geometries.Coordinate coordinate,
+        public static Result<RouterPoint> TryResolve(this Router router, Profile[] profiles, NetTopologySuite.Geometries.Coordinate coordinate,
             float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
             return router.TryResolve(profiles, (float)coordinate.Y, (float)coordinate.X,
@@ -85,7 +85,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest point on the routing network that's routable for the given profiles.
         /// </summary>
-        public static Result<RouterPoint> TryResolve(this Router router, Profile[] profiles, GeoAPI.Geometries.Coordinate coordinate,
+        public static Result<RouterPoint> TryResolve(this Router router, Profile[] profiles, NetTopologySuite.Geometries.Coordinate coordinate,
             Func<RoutingEdge, bool> isBetter, float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
             return router.TryResolve(profiles, (float)coordinate.Y, (float)coordinate.X, isBetter,
@@ -95,7 +95,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest point on the routing network that's routable for the given profiles.
         /// </summary>
-        public static RouterPoint Resolve(this Router router, Profile profile, GeoAPI.Geometries.Coordinate coordinate,
+        public static RouterPoint Resolve(this Router router, Profile profile, NetTopologySuite.Geometries.Coordinate coordinate,
             float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
             return router.TryResolve(profile, coordinate, searchDistanceInMeter).Value;
@@ -104,7 +104,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest point on the routing network that's routable for the given profiles.
         /// </summary>
-        public static RouterPoint Resolve(this Router router, Profile[] profiles, GeoAPI.Geometries.Coordinate coordinate,
+        public static RouterPoint Resolve(this Router router, Profile[] profiles, NetTopologySuite.Geometries.Coordinate coordinate,
             float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
             return router.TryResolve(profiles, coordinate, searchDistanceInMeter).Value;
@@ -113,7 +113,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest point on the routing network that's routable for the given profiles.
         /// </summary>
-        public static RouterPoint[] Resolve(this Router router, Profile profile, GeoAPI.Geometries.Coordinate[] coordinates,
+        public static RouterPoint[] Resolve(this Router router, Profile profile, NetTopologySuite.Geometries.Coordinate[] coordinates,
             float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
             var results = router.TryResolve(profile, coordinates, searchDistanceInMeter);
@@ -128,7 +128,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Searches for the closest point on the routing network that's routable for the given profiles.
         /// </summary>
-        public static RouterPoint Resolve(this Router router, Profile[] profiles, GeoAPI.Geometries.Coordinate coordinate,
+        public static RouterPoint Resolve(this Router router, Profile[] profiles, NetTopologySuite.Geometries.Coordinate coordinate,
             Func<RoutingEdge, bool> isBetter,
                 float searchDistanceInMeter = Constants.SearchDistanceInMeter)
         {
@@ -138,7 +138,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Calculates a route between the two locations.
         /// </summary>
-        public static Route Calculate(this Router router, Profile profile, GeoAPI.Geometries.Coordinate source, GeoAPI.Geometries.Coordinate target)
+        public static Route Calculate(this Router router, Profile profile, NetTopologySuite.Geometries.Coordinate source, NetTopologySuite.Geometries.Coordinate target)
         {
             return router.TryCalculate(profile, source, target).Value;
         }
@@ -146,7 +146,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Calculates a route along the given locations.
         /// </summary>
-        public static Route Calculate(this Router router, Profile profile, GeoAPI.Geometries.Coordinate[] locations)
+        public static Route Calculate(this Router router, Profile profile, NetTopologySuite.Geometries.Coordinate[] locations)
         {
             return router.TryCalculate(profile, locations).Value;
         }
@@ -154,8 +154,8 @@ namespace Itinero.Geo
         /// <summary>
         /// Calculates a route between the two locations.
         /// </summary>
-        public static Result<Route> TryCalculate(this Router router, Profile profile, GeoAPI.Geometries.Coordinate source,
-            GeoAPI.Geometries.Coordinate target)
+        public static Result<Route> TryCalculate(this Router router, Profile profile, NetTopologySuite.Geometries.Coordinate source,
+            NetTopologySuite.Geometries.Coordinate target)
         {
             return router.TryCalculate(profile, (float)source.Y, (float)source.X, (float)target.Y, (float)target.X);
         }
@@ -163,7 +163,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Calculates a route along the given locations.
         /// </summary>
-        public static Result<Route> TryCalculate(this Router router, Profile profile, GeoAPI.Geometries.Coordinate[] locations)
+        public static Result<Route> TryCalculate(this Router router, Profile profile, NetTopologySuite.Geometries.Coordinate[] locations)
         {
             if (locations.Length < 2)
             {
@@ -190,7 +190,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Calculates the weight between the two locations.
         /// </summary>
-        public static Result<T> TryCalculateWeight<T>(this Router router, Profile profile, WeightHandler<T> weightHandler, GeoAPI.Geometries.Coordinate source, GeoAPI.Geometries.Coordinate target)
+        public static Result<T> TryCalculateWeight<T>(this Router router, Profile profile, WeightHandler<T> weightHandler, NetTopologySuite.Geometries.Coordinate source, NetTopologySuite.Geometries.Coordinate target)
             where T : struct
         {
             return router.TryCalculateWeight(profile, weightHandler, (float)source.Y, (float)source.X, (float)target.Y, (float)target.X);
@@ -199,7 +199,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Calculates all weights between all given locations.
         /// </summary>
-        public static Result<T[][]> TryCalculateWeight<T>(this Router router, Profile profile, WeightHandler<T> weightHandler, GeoAPI.Geometries.Coordinate[] locations)
+        public static Result<T[][]> TryCalculateWeight<T>(this Router router, Profile profile, WeightHandler<T> weightHandler, LocalGeo.Coordinate[] locations)
             where T : struct
         {
             return router.TryCalculateWeight(profile, weightHandler, locations, locations);
@@ -208,7 +208,7 @@ namespace Itinero.Geo
         /// <summary>
         /// Calculates all weights between all sources and all targets.
         /// </summary>
-        public static Result<T[][]> TryCalculateWeight<T>(this Router router, Profile profile, WeightHandler<T> weightHandler, GeoAPI.Geometries.Coordinate[] sources, GeoAPI.Geometries.Coordinate[] targets)
+        public static Result<T[][]> TryCalculateWeight<T>(this Router router, Profile profile, WeightHandler<T> weightHandler, LocalGeo.Coordinate[] sources, LocalGeo.Coordinate[] targets)
             where T : struct
         {
             var resolvedSources = new RouterPoint[sources.Length];

--- a/src/Itinero.IO.Shape/Itinero.IO.Shape.csproj
+++ b/src/Itinero.IO.Shape/Itinero.IO.Shape.csproj
@@ -20,7 +20,7 @@
         <RepositoryType>routing, mapping, NTS</RepositoryType>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="NetTopologySuite.IO.ShapeFile" Version="1.15.3" />
+        <PackageReference Include="NetTopologySuite.IO.ShapeFile" Version="2.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Itinero.Geo\Itinero.Geo.csproj" />

--- a/src/Itinero.IO.Shape/Reader/ShapeFileReader.cs
+++ b/src/Itinero.IO.Shape/Reader/ShapeFileReader.cs
@@ -220,10 +220,10 @@ namespace Itinero.IO.Shape.Reader
                         nodeToVertex.TryGetValue(vertex2Shape, out vertex2))
                     { // the node has not been processed yet.
                         // add intermediates.
-                        var intermediates = new List<Coordinate>(lineString.Coordinates.Length);
+                        var intermediates = new List<LocalGeo.Coordinate>(lineString.Coordinates.Length);
                         for (int i = 1; i < lineString.Coordinates.Length - 1; i++)
                         {
-                            intermediates.Add(new Coordinate()
+                            intermediates.Add(new LocalGeo.Coordinate()
                             {
                                 Latitude = (float)lineString.Coordinates[i].Y,
                                 Longitude = (float)lineString.Coordinates[i].X
@@ -236,15 +236,15 @@ namespace Itinero.IO.Shape.Reader
                         if (_routerDb.Network.GetVertex(vertex1, out latitudeFrom, out longitudeFrom) &&
                             _routerDb.Network.GetVertex(vertex2, out latitudeTo, out longitudeTo))
                         { // calculate distance.
-                            var fromLocation = new Coordinate(latitudeFrom, longitudeFrom);
+                            var fromLocation = new LocalGeo.Coordinate(latitudeFrom, longitudeFrom);
                             for (int i = 0; i < intermediates.Count; i++)
                             {
-                                var currentLocation = new Coordinate(intermediates[i].Latitude, intermediates[i].Longitude);
-                                distance = distance + Coordinate.DistanceEstimateInMeter(fromLocation, currentLocation);
+                                var currentLocation = new LocalGeo.Coordinate(intermediates[i].Latitude, intermediates[i].Longitude);
+                                distance = distance + LocalGeo.Coordinate.DistanceEstimateInMeter(fromLocation, currentLocation);
                                 fromLocation = currentLocation;
                             }
-                            var toLocation = new Coordinate(latitudeTo, longitudeTo);
-                            distance = distance + Coordinate.DistanceEstimateInMeter(fromLocation, toLocation);
+                            var toLocation = new LocalGeo.Coordinate(latitudeTo, longitudeTo);
+                            distance = distance + LocalGeo.Coordinate.DistanceEstimateInMeter(fromLocation, toLocation);
                         }
 
                         // get profile and meta attributes.
@@ -289,10 +289,10 @@ namespace Itinero.IO.Shape.Reader
                                 var shape = intermediates;
                                 if (shape == null)
                                 { // make sure there is a shape.
-                                    shape = new List<Coordinate>();
+                                    shape = new List<LocalGeo.Coordinate>();
                                 }
 
-                                shape = new List<Coordinate>(shape);
+                                shape = new List<LocalGeo.Coordinate>(shape);
                                 shape.Insert(0, _routerDb.Network.GetVertex(vertex1));
                                 shape.Add(_routerDb.Network.GetVertex(vertex2));
 
@@ -302,11 +302,11 @@ namespace Itinero.IO.Shape.Reader
                                     tooBig = false;
                                     for (var s = 1; s < shape.Count; s++)
                                     {
-                                        var localDistance = Coordinate.DistanceEstimateInMeter(shape[s - 1], shape[s]);
+                                        var localDistance = LocalGeo.Coordinate.DistanceEstimateInMeter(shape[s - 1], shape[s]);
                                         if (localDistance >= _routerDb.Network.MaxEdgeDistance)
                                         { // insert a new intermediate.
                                             shape.Insert(s,
-                                                new Coordinate()
+                                                new LocalGeo.Coordinate()
                                                 {
                                                     Latitude = (float)(((double)shape[s - 1].Latitude +
                                                         (double)shape[s].Latitude) / 2.0),
@@ -320,14 +320,14 @@ namespace Itinero.IO.Shape.Reader
                                 }
 
                                 var i = 0;
-                                var shortShape = new List<Coordinate>();
+                                var shortShape = new List<LocalGeo.Coordinate>();
                                 var shortDistance = 0.0f;
                                 uint shortVertex = Constants.NO_VERTEX;
-                                Coordinate? shortPoint;
+                                LocalGeo.Coordinate? shortPoint;
                                 i++;
                                 while (i < shape.Count)
                                 {
-                                    var localDistance = Coordinate.DistanceEstimateInMeter(shape[i - 1], shape[i]);
+                                    var localDistance = LocalGeo.Coordinate.DistanceEstimateInMeter(shape[i - 1], shape[i]);
                                     if (localDistance + shortDistance > _routerDb.Network.MaxEdgeDistance)
                                     { // ok, previous shapepoint was the maximum one.
                                         shortPoint = shortShape[shortShape.Count - 1];
@@ -411,7 +411,7 @@ namespace Itinero.IO.Shape.Reader
         /// <summary>
         /// Adds a new edge.
         /// </summary>
-        private void AddEdge(uint vertex1, uint vertex2, Data.Network.Edges.EdgeData edgeData, List<Coordinate> intermediates)
+        private void AddEdge(uint vertex1, uint vertex2, Data.Network.Edges.EdgeData edgeData, List<LocalGeo.Coordinate> intermediates)
         {
             var edge = _routerDb.Network.GetEdgeEnumerator(vertex1).FirstOrDefault(x => x.To == vertex2);
             if (edge == null)
@@ -441,7 +441,7 @@ namespace Itinero.IO.Shape.Reader
                         edge.Shape != null)
                     { // no intermediates in current edge.
                       // save old edge data.
-                        intermediates = new List<Coordinate>(edge.Shape);
+                        intermediates = new List<LocalGeo.Coordinate>(edge.Shape);
                         vertex1 = edge.From;
                         vertex2 = edge.To;
                         splitMeta = edge.Data.MetaId;
@@ -464,7 +464,7 @@ namespace Itinero.IO.Shape.Reader
                         _routerDb.Network.AddVertex(newCoreVertex, intermediates[0].Latitude, intermediates[0].Longitude);
 
                         // calculate new distance and update old distance.
-                        var newDistance = Coordinate.DistanceEstimateInMeter(
+                        var newDistance = LocalGeo.Coordinate.DistanceEstimateInMeter(
                             _routerDb.Network.GetVertex(vertex1), intermediates[0]);
                         splitDistance -= newDistance;
 

--- a/src/Itinero.IO.Shape/Writer/FeaturesList.cs
+++ b/src/Itinero.IO.Shape/Writer/FeaturesList.cs
@@ -16,7 +16,6 @@
  *  limitations under the License.
  */
 
-using GeoAPI.Geometries;
 using Itinero.Algorithms.Collections;
 using Itinero.Geo;
 using Itinero.Logging;
@@ -176,8 +175,8 @@ namespace Itinero.IO.Shape.Writer
             var edge = _routerDb.Network.GetEdge((uint)index);
 
             var vertexLocation1 = _routerDb.Network.GeometricGraph.GetVertex(edge.From);
-            var coordinates = new List<Coordinate>();
-            coordinates.Add(new Coordinate(vertexLocation1.Longitude, vertexLocation1.Latitude));
+            var coordinates = new List<NetTopologySuite.Geometries.Coordinate>();
+            coordinates.Add(new NetTopologySuite.Geometries.Coordinate(vertexLocation1.Longitude, vertexLocation1.Latitude));
             var shape = edge.Shape;
             if (shape != null)
             {
@@ -185,12 +184,12 @@ namespace Itinero.IO.Shape.Writer
                 shapeEnumerable.Reset();
                 while (shapeEnumerable.MoveNext())
                 {
-                    coordinates.Add(new Coordinate(shapeEnumerable.Current.Longitude,
+                    coordinates.Add(new NetTopologySuite.Geometries.Coordinate(shapeEnumerable.Current.Longitude,
                         shapeEnumerable.Current.Latitude));
                 }
             }
             var vertexLocation2 = _routerDb.Network.GeometricGraph.GetVertex(edge.To);
-            coordinates.Add(new Coordinate(vertexLocation2.Longitude, vertexLocation2.Latitude));
+            coordinates.Add(new NetTopologySuite.Geometries.Coordinate(vertexLocation2.Longitude, vertexLocation2.Latitude));
             var geometry = new LineString(coordinates.ToArray());
 
             var length = 0.0f;

--- a/src/Itinero/Itinero.csproj
+++ b/src/Itinero/Itinero.csproj
@@ -20,9 +20,6 @@
     <RepositoryType>osm, openstreetmap, routing, mapping</RepositoryType>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Reminiscence" Version="1.3.0" />
-  </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);NETFX_CORE;DOTNET_CORE</DefineConstants>
   </PropertyGroup>
@@ -51,5 +48,8 @@
     <EmbeddedResource Include="Osm\Vehicles\smalltruck.lua">
       <LogicalName>Itinero.Osm.Vehicles.smalltruck.lua</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\reminiscence\src\Reminiscence\Reminiscence.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Itinero.Test.Functional/Staging/StagingHelper.cs
+++ b/test/Itinero.Test.Functional/Staging/StagingHelper.cs
@@ -9,16 +9,16 @@ namespace Itinero.Test.Functional.Staging
 {
     public static class StagingHelper
     {
-        public static Itinero.LocalGeo.Coordinate[] GetLocations(string geojsonFile)
+        public static LocalGeo.Coordinate[] GetLocations(string geojsonFile)
         {
             var features = GetFeatureCollection(geojsonFile);
 
-            var locations = new List<Itinero.LocalGeo.Coordinate>();
-            foreach (var feature in features.Features)
+            var locations = new List<LocalGeo.Coordinate>();
+            foreach (var feature in features)
             {
                 if (feature.Geometry is Point p)
                 {
-                    locations.Add(new Coordinate((float)p.Coordinate.Y, (float)p.Coordinate.X));
+                    locations.Add(new LocalGeo.Coordinate((float)p.Coordinate.Y, (float)p.Coordinate.X));
                 }
             }
 

--- a/test/Itinero.Test.Functional/Tests/RoutingTests.cs
+++ b/test/Itinero.Test.Functional/Tests/RoutingTests.cs
@@ -44,6 +44,7 @@ namespace Itinero.Test.Functional.Tests
             // normal.
             var profile = router.Db.GetSupportedProfile("car");
             GetTestRandomRoutes(router, profile, 1000).TestPerf($"{profile.FullName} random routes");
+            GetTestRandomRoutesParallel(router, profile, 1000);
             GetTestSequences(router, profile, 1).TestPerf($"{profile.FullName} sequences.");
             // directed.
             GetTestDirectedRandomRoutes(router, profile, 1000).TestPerf($"{profile.FullName} random directed routes");

--- a/test/Itinero.Test.Functional/Tests/Runner.cs
+++ b/test/Itinero.Test.Functional/Tests/Runner.cs
@@ -46,9 +46,9 @@ namespace Itinero.Test.Functional.Tests
         /// Tests resolving all points in the given feature collection.
         /// </summary>
         public static void TestResolve(Router router, FeatureCollection features,
-            Func<Router, GeoAPI.Geometries.Coordinate, Result<RouterPoint>> resolve)
+            Func<Router, NetTopologySuite.Geometries.Coordinate, Result<RouterPoint>> resolve)
         {
-            foreach (var feature in features.Features)
+            foreach (var feature in features)
             {
                 if (feature.Geometry is Point)
                 {
@@ -61,7 +61,7 @@ namespace Itinero.Test.Functional.Tests
         /// Tests resolving all points in the given feature collection.
         /// </summary>
         public static void TestResolve(Router router, string embeddedResourceId,
-            Func<Router, GeoAPI.Geometries.Coordinate, Result<RouterPoint>> resolve)
+            Func<Router, NetTopologySuite.Geometries.Coordinate, Result<RouterPoint>> resolve)
         {
             FeatureCollection featureCollection;
             using (var stream = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream(embeddedResourceId)))
@@ -169,7 +169,7 @@ namespace Itinero.Test.Functional.Tests
         /// </summary>
         public static Func<List<LocalGeo.Polygon>> GetTestIsochroneCalculation(Router router)
         {
-            return () => router.CalculateIsochrones(Itinero.Osm.Vehicles.Vehicle.Car.Fastest(), new Coordinate(49.80356608186087f, 6.102948188781738f),
+            return () => router.CalculateIsochrones(Itinero.Osm.Vehicles.Vehicle.Car.Fastest(), new LocalGeo.Coordinate(49.80356608186087f, 6.102948188781738f),
                 new List<float>() { 900, 1800 }, 18);
         }
 
@@ -178,7 +178,7 @@ namespace Itinero.Test.Functional.Tests
         /// </summary>
         public static Func<HeatmapResult> GetTestHeatmapCalculation(Router router)
         {
-            return () => router.CalculateHeatmap(Itinero.Osm.Vehicles.Vehicle.Car.Fastest(), new Coordinate(49.80356608186087f, 6.102948188781738f), 1800, 18);
+            return () => router.CalculateHeatmap(Itinero.Osm.Vehicles.Vehicle.Car.Fastest(), new LocalGeo.Coordinate(49.80356608186087f, 6.102948188781738f), 1800, 18);
         }
 
         /// <summary>

--- a/test/Itinero.Test/TestExtensions.cs
+++ b/test/Itinero.Test/TestExtensions.cs
@@ -37,12 +37,12 @@ namespace Itinero.Test
         /// <summary>
         /// Generates a random coordinate in the given box.
         /// </summary>
-        public static Coordinate GenerateRandomIn(this Box box)
+        public static Itinero.LocalGeo.Coordinate GenerateRandomIn(this Box box)
         {
             var xNext = (float) _random.NextDouble();
             var yNext = (float) _random.NextDouble();
 
-            return new Coordinate(box.MinLat + (box.MaxLat - box.MinLat) * xNext,
+            return new Itinero.LocalGeo.Coordinate(box.MinLat + (box.MaxLat - box.MinLat) * xNext,
                 box.MinLon + (box.MaxLon - box.MinLon) * yNext);
         }
 
@@ -60,7 +60,7 @@ namespace Itinero.Test
             return routerDb.Network.AddEdge(vertex1, vertex2,
                 new Itinero.Data.Network.Edges.EdgeData()
                 {
-                    Distance = Coordinate.DistanceEstimateInMeter(latitude1, longitude1, latitude2, longitude2),
+                    Distance = Itinero.LocalGeo.Coordinate.DistanceEstimateInMeter(latitude1, longitude1, latitude2, longitude2),
                     Profile = 0,
                     MetaId = 0
                 });
@@ -69,7 +69,7 @@ namespace Itinero.Test
         /// <summary>
         /// Loads a set of test points.
         /// </summary>
-        public static IEnumerable<Coordinate> LoadTestPoints(this Stream stream)
+        public static IEnumerable<Itinero.LocalGeo.Coordinate> LoadTestPoints(this Stream stream)
         {
             using (var streamReader = new StreamReader(stream))
             {
@@ -80,12 +80,12 @@ namespace Itinero.Test
         /// <summary>
         /// Loads a test network from geojson.
         /// </summary>
-        private static IEnumerable<Coordinate> LoadTestPoints(string geoJson)
+        private static IEnumerable<Itinero.LocalGeo.Coordinate> LoadTestPoints(string geoJson)
         {
             var geoJsonReader = new NetTopologySuite.IO.GeoJsonReader();
             var features = geoJsonReader.Read<FeatureCollection>(geoJson);
 
-            foreach (var feature in features.Features)
+            foreach (var feature in features)
             {
                 var point = feature.Geometry as Point;
                 if (point == null)
@@ -94,7 +94,7 @@ namespace Itinero.Test
                     ;
                 }
 
-                yield return new Coordinate((float) point.Coordinate.Y, (float) point.Coordinate.X);
+                yield return new Itinero.LocalGeo.Coordinate((float) point.Coordinate.Y, (float) point.Coordinate.X);
             }
         }
 

--- a/test/Itinero.Test/TestNetworkBuilder.cs
+++ b/test/Itinero.Test/TestNetworkBuilder.cs
@@ -57,7 +57,7 @@ namespace Itinero.Test
             var geoJsonReader = new NetTopologySuite.IO.GeoJsonReader();
             var features = geoJsonReader.Read<FeatureCollection>(geoJson);
 
-            foreach (var feature in features.Features)
+            foreach (var feature in features)
             {
                 if (feature.Geometry is Point)
                 {
@@ -100,7 +100,7 @@ namespace Itinero.Test
                 }
             }
 
-            foreach (var feature in features.Features)
+            foreach (var feature in features)
             {
                 if (feature.Geometry is LineString)
                 {
@@ -137,13 +137,13 @@ namespace Itinero.Test
                         (float)line.Coordinates[0].Y,
                         (float)line.Coordinates[0].X, tolerance);
                     var distance = 0.0;
-                    var shape = new List<Coordinate>();
+                    var shape = new List<Itinero.LocalGeo.Coordinate>();
                     for (var i = 1; i < line.Coordinates.Length; i++)
                     {
                         var vertex2 = db.SearchVertexFor(
                             (float)line.Coordinates[i].Y,
                             (float)line.Coordinates[i].X, tolerance);
-                        distance += Coordinate.DistanceEstimateInMeter(
+                        distance += Itinero.LocalGeo.Coordinate.DistanceEstimateInMeter(
                             (float)line.Coordinates[i - 1].Y, (float)line.Coordinates[i - 1].X,
                             (float)line.Coordinates[i].Y, (float)line.Coordinates[i].X);
                         if (vertex2 == Itinero.Constants.NO_VERTEX)
@@ -167,7 +167,7 @@ namespace Itinero.Test
                 }
             }
 
-            foreach (var feature in features.Features)
+            foreach (var feature in features)
             {
                 if (feature.Geometry is LineString &&
                     feature.Attributes.Contains("restriction", "yes"))
@@ -236,7 +236,7 @@ namespace Itinero.Test
                 float lat, lon;
                 if (db.Network.GetVertex(vertex, out lat, out lon))
                 {
-                    var dist = Coordinate.DistanceEstimateInMeter(latitude, longitude,
+                    var dist = Itinero.LocalGeo.Coordinate.DistanceEstimateInMeter(latitude, longitude,
                         lat, lon);
                     if (dist < tolerance)
                     {


### PR DESCRIPTION
I just made this because since I am having issues with or without contractions I figured I should help to try and track the issue down, this was a low hanging fruit and gets the later version of NTS in the library.

All tests seemed to pass on my machine so it's possible this threading issue is fixed in the develop branch of reminiscence, I will add a few more tests to make sure but there was already `GetTestRandomRoutesParallel` but it was not being run so I added that to the list of tests to run.