### PR TITLE
Only instantiate abstract class' properties once

### DIFF
--- a/src/Itinero/Profiles/Vehicle.cs
+++ b/src/Itinero/Profiles/Vehicle.cs
@@ -54,35 +54,17 @@ namespace Itinero.Profiles
         /// <summary>
         /// Gets the vehicle types.
         /// </summary>
-        public virtual string[] VehicleTypes
-        {
-            get
-            {
-                return new string[] { };
-            }
-        }
+        public virtual string[] VehicleTypes { get; } = [];
 
         /// <summary>
         /// Gets a whitelist of attributes to keep as meta-data.
         /// </summary>
-        public virtual HashSet<string> MetaWhiteList
-        {
-            get
-            {
-                return new HashSet<string>();
-            }
-        }
+        public virtual HashSet<string> MetaWhiteList { get; } = [];
 
         /// <summary>
         /// Gets a whitelist of attributes to keep as part of the profile.
         /// </summary>
-        public virtual HashSet<string> ProfileWhiteList
-        {
-            get
-            {
-                return new HashSet<string>();
-            }
-        }
+        public virtual HashSet<string> ProfileWhiteList { get; } = [];
 
         /// <summary>
         /// Adds a number of keys to the given whitelist when they are relevant for this vehicle.
@@ -215,7 +197,7 @@ namespace Itinero.Profiles
 
         /// <summary>
         /// Serializes the content of this vehicle.
-        /// </summary
+        /// </summary>
         protected virtual long DoSerialize(Stream stream)
         {
             return 0;


### PR DESCRIPTION
Every time `get` is called, a new instance of the type is returned. This changes it to just create it once
and return always that created instance.